### PR TITLE
Config formats

### DIFF
--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -3,15 +3,30 @@
 
 #include <regex>
 
+#include "logger.h"
+
 namespace logger {
-constexpr int THRESHOLD = 0;
-constexpr char filename[] = "hey.txt";
-constexpr char format[] = "%(%:%):";
-std::regex format_regex = std::regex("(.*)\\((.*):(.*)\\):(.*)");
 // using MyFormat = Format(date, line, ip);
 
 // Format("(%s:%s:%s)", date, line, ip);
-// constexpr FORMAT
+enum Severity {
+  NOTSET = 0,
+  DEBUG = 10,
+  INFO = 20,
+  WARNING = 30,
+  ERROR = 40,
+  CRITICAL = 50
+};
+
+constexpr const char format[] = "%(%:%):";
+using MainLogger = Logger<NOTSET, format, FILE, FUNC, LINE>;
+
+// * Log record : each line of the log
+// * log format : tuple like <Date, Name, Message>
+// * log property : Date, Name, Message
+#define LOG(severity)                                                          \
+  logger::MainLogger::getInstance().log<logger::severity>(                     \
+      {__FILE__, __func__, __LINE__})
 }
 
 #endif /* __LOGCONFIG_H__ */

--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -18,6 +18,12 @@ enum Severity {
 constexpr const char format[] = "%(%:%):";
 using MainLogger = Logger<DEBUG, format, prop_file, prop_func, prop_line>;
 
+// Example extended logger
+constexpr const char alt_fmt[] = "[%] %(%:%):";
+void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }
+using AltLogger =
+    Logger<DEBUG, alt_fmt, prop_ip, prop_file, prop_func, prop_line>;
+
 #define LOG(severity)                                                          \
   logger::MainLogger::getInstance().log<logger::severity>(                     \
       {__FILE__, __func__, __LINE__})

--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -6,9 +6,6 @@
 #include "logger.h"
 
 namespace logger {
-// using MyFormat = Format(date, line, ip);
-
-// Format("(%s:%s:%s)", date, line, ip);
 enum Severity {
   NOTSET = 0,
   DEBUG = 10,
@@ -19,11 +16,8 @@ enum Severity {
 };
 
 constexpr const char format[] = "%(%:%):";
-using MainLogger = Logger<NOTSET, format, FILE, FUNC, LINE>;
+using MainLogger = Logger<DEBUG, format, prop_file, prop_func, prop_line>;
 
-// * Log record : each line of the log
-// * log format : tuple like <Date, Name, Message>
-// * log property : Date, Name, Message
 #define LOG(severity)                                                          \
   logger::MainLogger::getInstance().log<logger::severity>(                     \
       {__FILE__, __func__, __LINE__})

--- a/include/logger.h
+++ b/include/logger.h
@@ -2,16 +2,10 @@
 #define __LOGGER_H__
 
 #include <iostream>
+#include <sstream>
 #include <memory>
 #include <mutex>
 #include <type_traits>
-
-// * Log record : each line of the log
-// * log format : tuple like <Date, Name, Message>
-// * log property : Date, Name, Message
-#define LOG(severity)                                                          \
-  logger::Logger::getInstance().log<logger::severity>(                         \
-      {__FILE__, __func__, __LINE__})
 
 std::string hex(intptr_t v) {
   std::stringstream ss;
@@ -21,44 +15,58 @@ std::string hex(intptr_t v) {
 
 namespace logger {
 
-// TODO: how to specify THRESHOLD in terms of these? make two header files? NO!
-// TODO: JEB suggested we should put these in the log config
-enum Severity {
-  NOTSET = 0,
-  DEBUG = 10,
-  INFO = 20,
-  WARNING = 30,
-  ERROR = 40,
-  CRITICAL = 50
+template <typename T> concept bool Streamable = requires(T o, std::ostream &s) {
+  { s << o } -> std::ostream &;
 };
-
-// auto date = []() { return std::to_string(GetDate()); }
-// auto line = [](const Record &f) { return std::to_string(f.line); }
 
 struct ContextInfo {
   const char *file, *fn;
   int line;
 };
 
-// Record("(%:%:%)", date, line, ip);
-// Record(const char *, f -> string...);
-template <const char *Fmt> class Record {
+enum property {
+  FILE, // - File name (CodeContext)
+  FUNC, // - Function name (CodeContext)
+  LINE, // - Line number (CodeContext)
+  // LEVEL
+  // NAME
+  // THREAD
+  // HASH
+  DATE, // - Date a Log Record is created (RunContext)
+  TIME, // - Time a Log Record is created (RunContext)
+  MESG  // - Added by the user
+};
+
+template <property prop> void stream_prop(std::ostream &o, const ContextInfo &i) {}
+template <> void stream_prop<FILE>(std::ostream &o, const ContextInfo &i) {
+  o << i.file;
+}
+template <> void stream_prop<FUNC>(std::ostream &o, const ContextInfo &i) {
+  o << i.fn;
+}
+template <> void stream_prop<LINE>(std::ostream &o, const ContextInfo &i) {
+  o << i.line;
+}
+
+// unfortunately can't do template<auto> yet; approved though
+// www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0127r1.html
+template <const char *fmt, property... props>
+class Record {
   std::ostream &stream;
   std::lock_guard<std::mutex> lock;
   ContextInfo info;
   intptr_t hash;
 
-  const char *format = Fmt;
+  const char *format = fmt;
 
   // adapted from cppreference parameter_pack page
   void print_prefix() { stream << format; }
 
-  template <typename T, typename... Targs>
-  void print_prefix(T head, Targs... tail) {
+  template <property Head, property... Tail> void print_prefix() {
     while (*format != '\0') {
       if (*(format++) == '%') {
-        stream << head;
-        print_prefix(tail...);
+        stream_prop<Head>(stream, info);
+        print_prefix<Tail...>();
         return;
       }
       stream << *(format - 1);
@@ -68,7 +76,7 @@ template <const char *Fmt> class Record {
 public:
   Record(std::ostream &s, ContextInfo input_info, std::mutex &Logging_lock)
       : stream(s), info(input_info), lock(Logging_lock), hash(0) {
-    print_prefix(info.file, info.fn, info.line);
+    print_prefix<props...>();
   }
   //  << std::hex
   ~Record() { stream << " " << hex(hash) << std::endl; }
@@ -86,6 +94,7 @@ public:
   template <typename T> NoRecord &operator<<(const T &s) { return *this; }
 };
 
+template <int threshold, const char *fmt, property... props>
 class Logger {
 private:
   std::mutex logging_lock;
@@ -98,13 +107,13 @@ public:
   }
 
   template <unsigned int N,
-            typename std::enable_if<N >= THRESHOLD>::type * = nullptr>
-  Record<format> log(ContextInfo info) {
+            typename std::enable_if<N >= threshold>::type * = nullptr>
+  Record<fmt, props...> log(ContextInfo info) {
     return {std::clog, info, logging_lock};
   }
 
   template <unsigned int N,
-            typename std::enable_if<N<THRESHOLD>::type * = nullptr> NoRecord
+            typename std::enable_if<N<threshold>::type * = nullptr> NoRecord
                 log(ContextInfo info) {
     return {};
   }

--- a/include/property.h
+++ b/include/property.h
@@ -9,6 +9,8 @@
 
 namespace clayer {
 
+std::regex format_regex = std::regex("(.*)\\((.*):(.*)\\):(.*)");
+
 // Concepts used for property reading and writing
 template <typename T> concept bool Streamable = requires(T o, std::ostream &s) {
   { s << o } -> std::ostream &;
@@ -116,7 +118,7 @@ void read_props(LogRecord &p, PS ps) {
 template <log_properties... I>
 void parse_props(LogRecord &p, std::string &line) {
   std::smatch m;
-  std::regex_match(line, m, logger::format_regex);
+  std::regex_match(line, m, format_regex);
   read_props<std::smatch::iterator, I...>(p, m.begin() + 1);
 }
 

--- a/src/analyser_test.cpp
+++ b/src/analyser_test.cpp
@@ -1,6 +1,6 @@
-#include "logconfig.h"
 #include "property.h"
 #include "analyser.h"
+#include "logconfig.h"
 
 using namespace clayer;
 


### PR DESCRIPTION
Significant, probably controversial changes to logger structure.
- Logger class now templated by format as well as threshold, rather than using global constants.
- We maintain the singleton invariant using type alias MainLogger, a fixed 'default' logger.
- Benefits: can put Severity in logconfig.h now; just need to define MainLogger afterwards.
- LOG macro is in an awkward _temporary_ spot now but I think it's made up for by the better placement of other things. In the future it'll be in a second library header probably, or maybe logger.h will include logconfig.h? (The way it is now it's much more palatable to have this nested inclusion)
- `format_regex` is in an awkward spot too now, but I think in a follow up PR we can just generate it on the fly using the format string. 

More configurable formats
- (Again) logger class templated by format string (e.g. "%(%:%)") as well as a list of functions that correspond to output at each %. 
- Functions corresponding to % are of form `void(std::ostream &, const ContextInfo &)`.
- The intention is that custom functions would be easily insertable with this interface. See `AltLogger` in logconfig.h

(Functionally equivalent so far)