### PR TITLE
configurable destination streams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TARGETS := bin/runner bin/analyser_test
 SRCEXT := cpp
 SOURCES := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
-CFLAGS := -g # -Wall
+CFLAGS := -g -Wall
 # LIB := -pthread -lmongoclient -L lib -lboost_thread-mt -lboost_filesystem-mt -lboost_system-mt
 INC := -I include
 

--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -1,7 +1,8 @@
 #ifndef __LOGCONFIG_H__
 #define __LOGCONFIG_H__
 
-#include <regex>
+#include <fstream>
+#include <iostream>
 
 #include "logger.h"
 
@@ -16,13 +17,15 @@ enum Severity {
 };
 
 constexpr const char format[] = "%(%:%):";
-using MainLogger = Logger<DEBUG, format, prop_file, prop_func, prop_line>;
+using MainLogger = Logger<DEBUG, std::ostream, std::clog,
+                          format, prop_file, prop_func, prop_line>;
 
 // Example extended logger
+std::ofstream log_stream("log.txt");
 constexpr const char alt_fmt[] = "[%] %(%:%):";
 void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }
-using AltLogger =
-    Logger<DEBUG, alt_fmt, prop_ip, prop_file, prop_func, prop_line>;
+using AltLogger = Logger<DEBUG, std::ofstream, log_stream,
+                         alt_fmt, prop_ip, prop_file, prop_func, prop_line>;
 
 #define LOG(severity)                                                          \
   logger::MainLogger::getInstance().log<logger::severity>(                     \

--- a/include/logger.h
+++ b/include/logger.h
@@ -30,8 +30,8 @@ void prop_line(std::ostream &o, const ContextInfo &i) { o << i.line; }
 template <const char *fmt, Prop... props>
 class Record {
   std::ostream &stream;
-  std::lock_guard<std::mutex> lock;
   ContextInfo info;
+  std::lock_guard<std::mutex> lock;
   intptr_t hash;
 
   const char *format = fmt;
@@ -72,7 +72,9 @@ public:
   template <typename T> NoRecord &operator<<(const T &s) { return *this; }
 };
 
-template <int threshold, const char *fmt, Prop... props>
+// Would like to have template<auto &stream> here too
+// www.open-std.org/jtc2/sc22/wg21/docs/papers/2016/p0127r1.html
+template <int threshold, typename T, T &stream, const char *fmt, Prop... props>
 class Logger {
 private:
   std::mutex logging_lock;
@@ -87,7 +89,7 @@ public:
   template <unsigned int N,
             typename std::enable_if<N >= threshold>::type * = nullptr>
   Record<fmt, props...> log(ContextInfo info) {
-    return {std::clog, info, logging_lock};
+    return {stream, info, logging_lock};
   }
 
   template <unsigned int N,


### PR DESCRIPTION
Logger class templated by destination stream for configurable output (but also the possibility of multiple output - not saying we should do this but I think having the option, then using a default logger is an elegant solution).