### PR TITLE
Local buffer + log levels

### DIFF
--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -45,10 +45,10 @@ void prop_thread(std::ostream &o, const Line &l) {
   o.flags(f);
 }
 
-constexpr const char format[] = "\033[1;31m[%]\033[0m %[%(%:%)]: [%]";
+constexpr const char format[] = "\033[1;31m[%]\033[0m %[%:%(%:%)]: [%]";
 using MainLogger =
     Logger<DEBUG, std::ostream, std::clog, format,
-           prop_time, prop_level, prop_file, prop_func, prop_line, prop_msg>;
+           prop_time, prop_level, prop_thread, prop_file, prop_func, prop_line, prop_msg>;
 
 // Example extended logger
 // void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }

--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -19,6 +19,18 @@ enum Severity {
   CRITICAL = 50
 };
 
+void prop_level(std::ostream &o, const Line &l) {
+  switch (l.info.level) {
+    case 0: o << "NOTSET"; break;
+    case 10: o << "DEBUG"; break;
+    case 20: o << "INFO"; break;
+    case 30: o << "WARNING"; break;
+    case 40: o << "ERROR"; break;
+    case 50: o << "CRITICAL"; break;
+    default: o << l.info.level;
+  }
+}
+
 // Can avoid the Line parameter in GCC 7 with template <auto>
 void prop_time(std::ostream &o, const Line &l) {
   using std::chrono::system_clock;
@@ -33,10 +45,10 @@ void prop_thread(std::ostream &o, const Line &l) {
   o.flags(f);
 }
 
-constexpr const char format[] = "\033[1;31m[%]\033[0m #% %(%:%): [%]";
+constexpr const char format[] = "\033[1;31m[%]\033[0m %[%(%:%)]: [%]";
 using MainLogger =
     Logger<DEBUG, std::ostream, std::clog, format,
-           prop_time, prop_hash, prop_file, prop_func, prop_line, prop_msg>;
+           prop_time, prop_level, prop_file, prop_func, prop_line, prop_msg>;
 
 // Example extended logger
 // void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }
@@ -47,7 +59,7 @@ using MainLogger =
 
 #define LOG(severity)                                                          \
   logger::MainLogger::getInstance().log<logger::severity>(                     \
-      {__FILE__, __func__, __LINE__})
+      {__FILE__, __func__, __LINE__, logger::severity})
 }
 
 #endif /* __LOGCONFIG_H__ */

--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -19,23 +19,24 @@ enum Severity {
   CRITICAL = 50
 };
 
-void prop_time(std::ostream &o, const ContextInfo &i) {
+// Can avoid the Line parameter in GCC 7 with template <auto>
+void prop_time(std::ostream &o, const Line &l) {
   using std::chrono::system_clock;
   auto now = system_clock::to_time_t(system_clock::now());
   o << std::put_time(std::localtime(&now), "%F %T");
 }
 
-void prop_thread(std::ostream &o, const ContextInfo &i) {
+void prop_thread(std::ostream &o, const Line &l) {
   auto f = o.flags();
   o << std::hex << std::showbase << "Thread " << std::hex << std::showbase
     << std::this_thread::get_id();
   o.flags(f);
 }
 
-constexpr const char format[] = "\033[1;31m[%]\033[0m % %(%:%): [%]";
+constexpr const char format[] = "\033[1;31m[%]\033[0m #% %(%:%): [%]";
 using MainLogger =
     Logger<DEBUG, std::ostream, std::clog, format,
-           prop_time, prop_thread, prop_file, prop_func, prop_line, prop_msg>;
+           prop_time, prop_hash, prop_file, prop_func, prop_line, prop_msg>;
 
 // Example extended logger
 // void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }

--- a/include/logger.h
+++ b/include/logger.h
@@ -11,7 +11,7 @@ namespace logger {
   
 struct ContextInfo {
   const char *file, *fn;
-  int line;
+  int line, level;
 };
 
 struct Line {

--- a/include/logger.h
+++ b/include/logger.h
@@ -9,78 +9,82 @@
 
 namespace logger {
   
-static void stream_hex(std::ostream &ss, intptr_t v) {
-  auto ff = ss.flags();
-  ss << std::hex << std::showbase << v;
-  ss.flags(ff);
-}
-
 struct ContextInfo {
   const char *file, *fn;
   int line;
 };
 
-using Prop = void (*)(std::ostream &, const ContextInfo &);
-void prop_msg(std::ostream &o, const ContextInfo &i) { }
-void prop_func(std::ostream &o, const ContextInfo &i) { o << i.fn; }
-void prop_file(std::ostream &o, const ContextInfo &i) { o << i.file; }
-void prop_line(std::ostream &o, const ContextInfo &i) { o << i.line; }
+struct Line {
+  ContextInfo info;
+  std::ostringstream message;
+  intptr_t hash;
+  Line(const ContextInfo &i) : info(i), message(), hash(0) {}
+};
+
+using Prop = void (*)(std::ostream &, const Line &);
+void prop_msg(std::ostream &o, const Line &l) { o << l.message.str(); }
+void prop_hash(std::ostream &o, const Line &l) { o << l.hash; }
+void prop_func(std::ostream &o, const Line &l) { o << l.info.fn; }
+void prop_file(std::ostream &o, const Line &l) { o << l.info.file; }
+void prop_line(std::ostream &o, const Line &l) { o << l.info.line; }
+
+template <bool Flag> class HashFlag {
+  HashFlag() {}
+public:
+  const static HashFlag<Flag> inst;
+};
+
+template <bool Flag> const HashFlag<Flag> HashFlag<Flag>::inst;
+const HashFlag<true> &EnableHash = HashFlag<true>::inst;
+const HashFlag<false> &DisableHash = HashFlag<false>::inst;
 
 // unfortunately can't do template<auto> yet; approved though
 // www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0127r1.html
 template <const char *fmt, Prop... props>
 class Record {
   std::ostream &stream;
-  ContextInfo info;
-  std::lock_guard<std::mutex> lock;
-  bool done = false;
-  intptr_t hash;
+  Line line;
+  bool hash_enabled;
+  std::mutex &logging_mutex;
 
   const char *format = fmt;
 
   // adapted from cppreference parameter_pack page
-  void print_prefix() {
+  void print_fmt() {
     stream << format;
-    done = true; // reach end of arg. list. nothing to print after
   }
 
   template <typename T, typename... Targs>
-  void print_prefix(T head, Targs... tail) {
+  void print_fmt(T head, Targs... tail) {
     while (*format != '\0') {
       if (*(format++) == '%') {
-        if (head == &prop_msg)
-          return;
-        head(stream, info);
-        print_prefix(tail...);
+        head(stream, line);
+        print_fmt(tail...);
         return;
       }
       stream << *(format - 1);
     }
-    done = true; // reached end of format string; nothing to print after
-  }
-
-  void print_suffix() { if (!done) print_prefix(); }
-
-  // resume printing after the prop_msg argument
-  template <typename T, typename... Targs>
-  void print_suffix(T head, Targs... tail) {
-    if (done) return;
-    if (head != &prop_msg)
-      print_suffix(tail...);
-    else
-      print_prefix(tail...);
   }
 
 public:
-  Record(std::ostream &s, ContextInfo input_info, std::mutex &Logging_lock)
-      : stream(s), info(input_info), lock(Logging_lock), hash(0) {
-    print_prefix(props...);
+  Record(std::ostream &s, ContextInfo input_info, std::mutex &mutex)
+      : stream(s), line(input_info), hash_enabled(true),
+        logging_mutex(mutex) {}
+  ~Record() {
+    std::lock_guard<std::mutex> lock(logging_mutex);
+    print_fmt(props...);
+    stream << std::endl;
   }
-  ~Record() { print_suffix(props...); stream << std::endl; }
+
+  template <bool Flag> Record &operator<<(const HashFlag<Flag> &s) {
+    hash_enabled = Flag;
+    return *this;
+  }
 
   template <typename S> Record &operator<<(const S &s) {
-    hash ^= intptr_t(&s);
-    if (!done) stream << s;
+    if (hash_enabled)
+      line.hash ^= intptr_t(&s);
+    line.message << s;
     return *this;
   }
 };

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -15,7 +15,7 @@ void withdraw(int &account) {
 void deposit(int &account) {
   for (int i = 0; i < iterations; i++) {
     account++;
-    LOG(INFO) << "Balance after deposit: " << account;
+    LOG(INFO) << logger::DisableHash << "Balance after deposit: " << logger::EnableHash << account;
   }
 }
 


### PR DESCRIPTION
Expose log levels to the format, use a local buffer for the log records, and add options to include or exclude parts of the message from the hash.