### PR TITLE
Multi log

### DIFF
--- a/include/logconfig.h
+++ b/include/logconfig.h
@@ -19,7 +19,8 @@ enum Severity {
   CRITICAL = 50
 };
 
-void prop_level(std::ostream &o, const Line &l) {
+template <typename Stream>
+void prop_level(Stream &o, const Line &l) {
   switch (l.info.level) {
     case 0: o << "NOTSET"; break;
     case 10: o << "DEBUG"; break;
@@ -32,39 +33,35 @@ void prop_level(std::ostream &o, const Line &l) {
 }
 
 // Can avoid the Line parameter in GCC 7 with template <auto>
-void prop_time(std::ostream &o, const Line &l) {
+template <typename Stream>
+void prop_time(Stream &o, const Line &l) {
   using std::chrono::system_clock;
   auto now = system_clock::to_time_t(system_clock::now());
   o << std::put_time(std::localtime(&now), "%F %T");
 }
 
-void prop_thread(std::ostream &o, const Line &l) {
+template <typename Stream>
+void prop_thread(Stream &o, const Line &l) {
   auto f = o.flags();
-  o << std::hex << std::showbase << "Thread " << std::hex << std::showbase
-    << std::this_thread::get_id();
+  o << std::hex << std::showbase << std::this_thread::get_id();
   o.flags(f);
 }
 
-constexpr const char format[] = "\033[1;31m[%]\033[0m %[%:%(%:%)]: [%]";
-using MainLogger =
-    Logger<DEBUG, std::ostream, std::clog, format,
-           prop_time, prop_level, prop_thread, prop_file, prop_func, prop_line, prop_msg>;
+constexpr const char full_fmt[] = "\033[1;31m[%]\033[0m %[%:%(%:%)]: [%]";
+template <typename Stream>
+using FullLogger =
+    Logger<0, Stream, full_fmt, prop_time, prop_level, prop_thread, prop_file,
+           prop_func, prop_line, prop_msg>;
 
-// Example extended logger
-// void prop_ip(std::ostream &o, const ContextInfo &i) { o << "127.0.0.1"; }
-// std::ofstream log_stream("log.txt");
-// constexpr const char alt_fmt[] = "%(%:%): % [%]";
-// using AltLogger = Logger<DEBUG, std::ofstream, log_stream, alt_fmt,
-//                         prop_file, prop_func, prop_line, prop_msg, prop_ip>;
-
+constexpr const char basic_fmt[] = "%";
+template <typename Stream>
+using BasicLogger = Logger<INFO, Stream, basic_fmt, prop_msg>;
 }
 
-auto &LOG = logger::MainLogger::getInstance();
-#define LOG(severity)                                                          \
-  LOG.log<logger::severity>({__FILE__, __func__, __LINE__, logger::severity})
-
-#define CLOG(instance, severity)                                               \
-  instance.log<logger::severity>(                                              \
-      {__FILE__, __func__, __LINE__, logger::severity})
+logger::FullLogger<std::ostream> LOG(std::clog);
+#define LOG(severity) CLOG(LOG, severity)
+#define CLOG(instance, severity) CLOGL(instance, logger::severity)
+#define CLOGL(instance, severity)                                              \
+  instance.log<severity>({__FILE__, __func__, __LINE__, severity})
 
 #endif /* __LOGCONFIG_H__ */

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -8,14 +8,15 @@ const int iterations = 1000;
 void withdraw(int &account) {
   for (int i = 0; i < iterations; i++) {
     account--;
-    LOG(WARNING) << "Balance after withdraw: "<< account;
+    LOG(WARNING) << "Balance after withdraw: " << account;
   }
 }
 
 void deposit(int &account) {
   for (int i = 0; i < iterations; i++) {
     account++;
-    LOG(INFO) << logger::DisableHash << "Balance after deposit: " << logger::EnableHash << account;
+    LOG(INFO) << logger::hash::off
+              << "Balance after deposit: " << logger::hash::on << account;
   }
 }
 


### PR DESCRIPTION
- Changed logging architecture to allow instantiating loggers rather than using singletons. Default logger (LOG(DEBUG/ERROR/WARNING/...)) is provided though.
- Allow lines to be composed with streams other than std::ostream. 
- logging::EnableHash is now logging::hash::on